### PR TITLE
SAGE-1581: updated to leverage the cloud manifest

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,9 @@
+[run]
+omit=test.py
+
+[report]
+show_missing=True
+fail_under=85
+precision=1
+exclude_lines =
+    pragma: no cover

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,0 +1,13 @@
+name: Run tests
+
+on:
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Run tests
+        run: make test

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,6 @@
+all:
+
+.PHONY: test
+test:
+	docker build -t wes-device-labeler .
+	docker run --rm --entrypoint=sh wes-device-labeler -c 'coverage run -m unittest -v test.py; coverage report'

--- a/README.md
+++ b/README.md
@@ -1,0 +1,13 @@
+# Device Labeler
+
+The [WES](https://github.com/waggle-sensor/waggle-edge-stack) device labeler is responsible for applying Kubernetes "labels" to the compute nodes based upon sensor/resource availability to assist the Kubernetes scheduler to place pods on the correct compute units. For example, if the "microphone" is physically connected to a Raspberry Pi compute unit, it labels that Raspberry Pi with the `resource.microphone` label.
+
+## How it works
+
+The device labeler reads the [Waggle node's manifest](https://auth.sagecontinuum.org/manifests/) [ConfigMap](https://auth.sagecontinuum.org/manifests/) and then applies 3 items to the kubernetes compute node (ex. `000048b02d0766be.ws-nxcore`) labels.
+
+1. the compute unit's hardware capabilities (ex. `gpu`, `arm64`, `cuda102`) [added as `resource.*`]
+2. the list of connected sensors [added as `resource.*`]
+3. the compute unit's `zone` (ex. `shield`) [added as `zone.*`]
+
+> The list of connected sensors are verified to ensure the physical hardware sensor is available. If the hardware is not found the `resource.*` label for that sensor is **NOT** applied.

--- a/README.md
+++ b/README.md
@@ -11,3 +11,7 @@ The device labeler reads the [Waggle node's manifest](https://auth.sagecontinuum
 3. the compute unit's `zone` (ex. `shield`) [added as `zone.*`]
 
 > The list of connected sensors are verified to ensure the physical hardware sensor is available. If the hardware is not found the `resource.*` label for that sensor is **NOT** applied.
+
+## Unit Testing
+
+The `test.py` file contains [mocked](https://docs.python.org/3.8/library/unittest.mock.html) functions for the [Kubernetes](https://pypi.org/project/kubernetes/) function calls and simulations of the physical hardware tests. **When new hardware detection is added, the simulation for that hardware detection will need to be added.**

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
-kubernetes
+kubernetes==25.3.0
+coverage==6.5.0

--- a/test.py
+++ b/test.py
@@ -1,0 +1,191 @@
+import argparse
+import sys
+import tempfile
+import unittest
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+from main import main
+
+NODE_NONE = "0000000000000000.ws-none"
+NODE_NXCORE = "0000000000000001.ws-nxcore"
+NODE_NXAGENT = "0000000000000002.ws-nxagent"
+NODE_RPI_SHIELD = "0000000000000003.ws-rpi"
+NODE_RPI_ENCLOSURE = "0000000000000004.ws-rpi"
+NODE_BLADECORE = "0000000000000005.sb-core"
+
+NODE_MANIFEST_WSN = "test_files/node-manifest-v2-wsn.json"
+NODE_MANIFEST_BLADE = "test_files/node-manifest-v2-blade.json"
+NODE_MANIFEST_HW_DETECT_FAIL = "test_files/node-manifest-v2-lidar-fail.json"
+
+
+@patch("kubernetes.config.load_incluster_config", return_value=Mock())
+@patch("kubernetes.config.load_kube_config", return_value=Mock())
+# this 'bogus' resource should not show up in any results (i.e. be removed)
+@patch(
+    "kubernetes.client.CoreV1Api",
+    return_value=Mock(
+        read_node=Mock(return_value=Mock(metadata=Mock(labels={"resource.bogus=True"})))
+    ),
+)
+@patch("subprocess.check_output", return_value=Mock(decode=Mock(return_value="Microphone")))
+class TestService(unittest.TestCase):
+    def setUp(self):
+        self.root_tmpdr = tempfile.TemporaryDirectory()
+        self.root = self.root_tmpdr.name
+        Path.mkdir(Path(self.root, "dev"), parents=True)
+        Path.mkdir(Path(self.root, "sys/bus/iio/devices/iio1"), parents=True)
+        Path.mkdir(Path(self.root, "sys/bus/iio/devices/iio2"), parents=True)
+
+    def tearDown(self):
+        self.root_tmpdr.cleanup()
+
+    def testNXCore(self, mock_k_lic, mock_k_lkc, mock_k_core, mock_subprocess):
+        with patch("argparse.ArgumentParser.parse_args") as mock:
+
+            # make the fake device and system files
+            Path(self.root, "dev/gps").touch()
+            Path(self.root, "dev/airquality").touch()
+            with open(Path(self.root, "sys/bus/iio/devices/iio1/name"), "w") as f:
+                f.write("bme280")
+
+            with self.assertLogs() as logs:
+                mock.return_value = argparse.Namespace(
+                    debug=None,
+                    dry_run=True,
+                    kubeconfig=None,
+                    kubenode=NODE_NXCORE,
+                    root=self.root,
+                    manifest=NODE_MANIFEST_WSN,
+                    oneshot=True,
+                )
+                main()
+        self.assertIn(
+            "INFO:root:applying resources: airquality, arm64, bme280, cuda102, gps, gpu",
+            logs.output,
+        )
+        self.assertIn("INFO:root:applying zone: core", logs.output)
+
+    def testNXAgent(self, mock_k_lic, mock_k_lkc, mock_k_core, mock_subprocess):
+        with patch("argparse.ArgumentParser.parse_args") as mock:
+
+            # no device/system files
+
+            with self.assertLogs() as logs:
+                mock.return_value = argparse.Namespace(
+                    debug=None,
+                    dry_run=True,
+                    kubeconfig=None,
+                    kubenode=NODE_NXAGENT,
+                    root=self.root,
+                    manifest=NODE_MANIFEST_WSN,
+                    oneshot=True,
+                )
+                main()
+        self.assertIn("INFO:root:applying resources: arm64, cuda102, gpu, poe", logs.output)
+        # Test for a compute unit withOUT a 'zone' set
+        self.assertIn("INFO:root:applying zone: None", logs.output)
+
+    def testNXRPiShield(self, mock_k_lic, mock_k_lkc, mock_k_core, mock_subprocess):
+        with patch("argparse.ArgumentParser.parse_args") as mock:
+
+            # make the fake device and system files
+            Path(self.root, "dev/ttyUSB0").touch()
+            with open(Path(self.root, "sys/bus/iio/devices/iio2/name"), "w") as f:
+                f.write("bme680")
+
+            with self.assertLogs() as logs:
+                mock.return_value = argparse.Namespace(
+                    debug=None,
+                    dry_run=True,
+                    kubeconfig=None,
+                    kubenode=NODE_RPI_SHIELD,
+                    root=self.root,
+                    manifest=NODE_MANIFEST_WSN,
+                    oneshot=True,
+                )
+                main()
+        self.assertIn(
+            "INFO:root:applying resources: arm64, bme680, microphone, poe, rainguage", logs.output
+        )
+        self.assertIn("INFO:root:applying zone: shield", logs.output)
+
+    def testNXRPiEnclosure(self, mock_k_lic, mock_k_lkc, mock_k_core, mock_subprocess):
+        with patch("argparse.ArgumentParser.parse_args") as mock:
+
+            # make the fake device and system files
+            with open(Path(self.root, "sys/bus/iio/devices/iio2/name"), "w") as f:
+                f.write("bme680")
+
+            with self.assertLogs() as logs:
+                mock.return_value = argparse.Namespace(
+                    debug=None,
+                    dry_run=True,
+                    kubeconfig=None,
+                    kubenode=NODE_RPI_ENCLOSURE,
+                    root=self.root,
+                    manifest=NODE_MANIFEST_WSN,
+                    oneshot=True,
+                )
+                main()
+        self.assertIn("INFO:root:applying resources: arm64, bme680, poe", logs.output)
+        self.assertIn("INFO:root:applying zone: enclosure", logs.output)
+
+    def testBladeCore(self, mock_k_lic, mock_k_lkc, mock_k_core, mock_subprocess):
+        with patch("argparse.ArgumentParser.parse_args") as mock:
+
+            # make the fake device and system files
+            Path(self.root, "dev/gps").touch()
+            Path(self.root, "dev/airquality").touch()
+            with open(Path(self.root, "sys/bus/iio/devices/iio1/name"), "w") as f:
+                f.write("bme280")
+
+            with self.assertLogs() as logs:
+                mock.return_value = argparse.Namespace(
+                    debug=None,
+                    dry_run=True,
+                    kubeconfig=None,
+                    kubenode=NODE_BLADECORE,
+                    root=self.root,
+                    manifest=NODE_MANIFEST_BLADE,
+                    oneshot=True,
+                )
+                main()
+        self.assertIn("INFO:root:applying resources: amd64, cuda110, gpu", logs.output)
+        self.assertIn("INFO:root:applying zone: core", logs.output)
+
+    def testMissingCompute(self, mock_k_lic, mock_k_lkc, mock_k_core, mock_subprocess):
+        with patch("argparse.ArgumentParser.parse_args") as mock:
+            with self.assertRaises(Exception):
+                with self.assertLogs() as logs:
+                    mock.return_value = argparse.Namespace(
+                        debug=None,
+                        dry_run=True,
+                        kubeconfig=None,
+                        kubenode=NODE_NONE,
+                        root=self.root,
+                        manifest=NODE_MANIFEST_WSN,
+                        oneshot=True,
+                    )
+                    main()
+
+    # TODO: TEST FOR exception when there is no test for a piece of hardware
+    def testMissingHardwareFunction(self, mock_k_lic, mock_k_lkc, mock_k_core, mock_subprocess):
+        with patch("argparse.ArgumentParser.parse_args") as mock:
+            with self.assertLogs() as logs:
+                mock.return_value = argparse.Namespace(
+                    debug=None,
+                    dry_run=True,
+                    kubeconfig=None,
+                    kubenode=NODE_RPI_ENCLOSURE,
+                    root=self.root,
+                    manifest=NODE_MANIFEST_HW_DETECT_FAIL,
+                    oneshot=True,
+                )
+                main()
+        combined_out = "".join(logs.output)
+        self.assertIn("ERROR:root:Hardware detection function for [lidar] not found", combined_out)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/test_files/node-manifest-v2-blade.json
+++ b/test_files/node-manifest-v2-blade.json
@@ -1,0 +1,32 @@
+{
+    "vsn": "V002",
+    "name": "000048B02D0766BE",
+    "gps_lat": null,
+    "gps_lon": null,
+    "tags": [],
+    "computes": [
+        {
+            "hardware": {
+                "hardware": "compute-dell-xr2",
+                "hw_model": "PowerEdge XR2",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "16000",
+                "cpu_ram": "32768",
+                "gpu_ram": "16384",
+                "shared_ram": false,
+                "capabilities": [
+                    "gpu",
+                    "amd64",
+                    "cuda110"
+                ]
+            },
+            "name": "sbcore",
+            "serial_no": "0000000000000005",
+            "zone": "core"
+        }
+    ],
+    "sensors": [],
+    "resources": []
+}

--- a/test_files/node-manifest-v2-lidar-fail.json
+++ b/test_files/node-manifest-v2-lidar-fail.json
@@ -1,0 +1,49 @@
+{
+    "vsn": "W030",
+    "name": "000048B02D0766BE",
+    "gps_lat": null,
+    "gps_lon": null,
+    "tags": [],
+    "computes": [
+        {
+            "hardware": {
+                "hardware": "compute-rpi-4gb",
+                "hw_model": "RPI4B",
+                "hw_version": "rpi4b-4g",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "4000",
+                "cpu_ram": "4096",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": [
+                    "arm64",
+                    "poe"
+                ]
+            },
+            "name": "rpi-enclosure",
+            "serial_no": "000000000004",
+            "zone": "enclosure"
+        }
+    ],
+    "sensors": [
+        {
+            "hardware": {
+                "hardware": "lidar",
+                "hw_model": "OS0 Rev06",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "lidar",
+            "scope": "rpi-enclosure",
+            "labels": []
+        }
+    ],
+    "resources": []
+}

--- a/test_files/node-manifest-v2-wsn.json
+++ b/test_files/node-manifest-v2-wsn.json
@@ -1,0 +1,343 @@
+{
+    "vsn": "W030",
+    "name": "000048B02D0766BE",
+    "gps_lat": null,
+    "gps_lon": null,
+    "tags": [],
+    "computes": [
+        {
+            "hardware": {
+                "hardware": "compute-xaviernx",
+                "hw_model": "xavierNX",
+                "hw_version": "NGX003",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "6000",
+                "cpu_ram": "8092",
+                "gpu_ram": "8092",
+                "shared_ram": true,
+                "capabilities": [
+                    "gpu",
+                    "arm64",
+                    "cuda102"
+                ]
+            },
+            "name": "nxcore",
+            "serial_no": "000000000001",
+            "zone": "core"
+        },
+        {
+            "hardware": {
+                "hardware": "compute-xaviernx-poe",
+                "hw_model": "xavierNX",
+                "hw_version": "NGX002",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "6000",
+                "cpu_ram": "8092",
+                "gpu_ram": "8092",
+                "shared_ram": true,
+                "capabilities": [
+                    "gpu",
+                    "arm64",
+                    "cuda102",
+                    "poe"
+                ]
+            },
+            "name": "nxagent",
+            "serial_no": "000000000002",
+            "zone": ""
+        },
+        {
+            "hardware": {
+                "hardware": "compute-rpi-4gb",
+                "hw_model": "RPI4B",
+                "hw_version": "rpi4b-4g",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "4000",
+                "cpu_ram": "4096",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": [
+                    "arm64",
+                    "poe"
+                ]
+            },
+            "name": "rpi-shield",
+            "serial_no": "000000000003",
+            "zone": "shield"
+        },
+        {
+            "hardware": {
+                "hardware": "compute-rpi-4gb",
+                "hw_model": "RPI4B",
+                "hw_version": "rpi4b-4g",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "4000",
+                "cpu_ram": "4096",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": [
+                    "arm64",
+                    "poe"
+                ]
+            },
+            "name": "rpi-enclosure",
+            "serial_no": "000000000004",
+            "zone": "enclosure"
+        }
+    ],
+    "sensors": [
+        {
+            "hardware": {
+                "hardware": "fe-8010",
+                "hw_model": "XNF-8010RV",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "top-camera",
+            "scope": "global",
+            "labels": [
+                "top"
+            ]
+        },
+        {
+            "hardware": {
+                "hardware": "ptz-8081",
+                "hw_model": "XNV-8081Z",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "bottom-camera",
+            "scope": "global",
+            "labels": [
+                "bottom"
+            ]
+        },
+        {
+            "hardware": {
+                "hardware": "bme280",
+                "hw_model": "BME280",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "bme280",
+            "scope": "nxcore",
+            "labels": []
+        },
+        {
+            "hardware": {
+                "hardware": "gps",
+                "hw_model": "VK-162",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "gps",
+            "scope": "nxcore",
+            "labels": []
+        },
+        {
+            "hardware": {
+                "hardware": "bme680",
+                "hw_model": "BME680",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "bme680",
+            "scope": "rpi-shield",
+            "labels": []
+        },
+        {
+            "hardware": {
+                "hardware": "bme680",
+                "hw_model": "BME680",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "bme680",
+            "scope": "rpi-enclosure",
+            "labels": []
+        },
+        {
+            "hardware": {
+                "hardware": "microphone",
+                "hw_model": "ML1-WS IP54",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "microphone",
+            "scope": "rpi-shield",
+            "labels": []
+        },
+        {
+            "hardware": {
+                "hardware": "rainguage",
+                "hw_model": "RG-15",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "rainguage",
+            "scope": "rpi-shield",
+            "labels": []
+        },
+        {
+            "hardware": {
+                "hardware": "airquality",
+                "hw_model": "Metone ES-642",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "airquality",
+            "scope": "nxcore",
+            "labels": []
+        }
+    ],
+    "resources": [
+        {
+            "hardware": {
+                "hardware": "psu-B0BD",
+                "hw_model": "RCB600",
+                "hw_version": "B0BD",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "psu"
+        },
+        {
+            "hardware": {
+                "hardware": "resource-switch",
+                "hw_model": "ES-8-150W",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "switch"
+        },
+        {
+            "hardware": {
+                "hardware": "resource-usbhub-10port",
+                "hw_model": "HB30A10AME",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "usb-10-port"
+        },
+        {
+            "hardware": {
+                "hardware": "resource-usbhub-2port",
+                "hw_model": "B07TPS44SL",
+                "hw_version": "",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "usb-2-port"
+        },
+        {
+            "hardware": {
+                "hardware": "resource-wagman",
+                "hw_model": "wagmanv5",
+                "hw_version": "v5.0",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "wagman"
+        },
+        {
+            "hardware": {
+                "hardware": "resource-wifi-1",
+                "hw_model": "AC650",
+                "hw_version": "v2",
+                "sw_version": "",
+                "datasheet": "<url>",
+                "cpu": "",
+                "cpu_ram": "",
+                "gpu_ram": "",
+                "shared_ram": false,
+                "capabilities": []
+            },
+            "name": "wifi"
+        }
+    ]
+}


### PR DESCRIPTION
- apply a `zone` to any compute node that specifies one
- add a `resource.` label for all compute node's capabilities
- remove the hard-coded `gpu` labeling in favor of the node compatibility
- only apply a `resource.` label for a sensor if the manifest lists it
  and the hardware if physically detected