### PR TITLE
SAGE-1581: correct false compute unit matches; match entire compute mac address

### DIFF
--- a/main.py
+++ b/main.py
@@ -95,12 +95,13 @@ def main():
         # get the manifest compute dict for this node
         manifest_compute = None
         for compute in manifest["computes"]:
-            if compute["serial_no"].lower() in args.kubenode.lower():
+            # strip the kube node to the 12 character mac address (0000e45f012a1f42.ws-rpi -> e45f012a1f42)
+            if compute["serial_no"].lower() == args.kubenode.lower().split(".")[0][-12:]:
                 manifest_compute = compute
                 break
 
         if not manifest_compute:
-            raise Exception("Unable to find compute `%s` in manifest", args.kubenode)
+            raise Exception(f"Unable to find compute {args.kubenode} in manifest")
 
         # get list of sensors associated to this node
         node_sensors = [s for s in manifest["sensors"] if s["scope"] == manifest_compute["name"]]

--- a/test_files/node-manifest-v2-blade.json
+++ b/test_files/node-manifest-v2-blade.json
@@ -23,7 +23,7 @@
                 ]
             },
             "name": "sbcore",
-            "serial_no": "0000000000000005",
+            "serial_no": "000000000005",
             "zone": "core"
         }
     ],


### PR DESCRIPTION
Before this change an empty ("") compute 'serial_no' (i.e. mac address) was matching as the empty ("") string is "in" every other string. Instead, only match the compute if the 'serial_no' (i.e. mac address) is an exact match to the mac address embedded in the kube node name.