### PR TITLE
Added support for waggle-* udev based names

### DIFF
--- a/main.py
+++ b/main.py
@@ -182,7 +182,7 @@ def main():
         # config tracked by the time a udev rule is actually set.
         for path in Path(args.root, "dev").glob("waggle-*"):
             name = removeprefix(path.name, "waggle-")
-            if not re.fullmatch(r"[a-z0-9-]", name):
+            if not re.fullmatch(r"[a-z0-9-]+", name):
                 logging.warning("invalid device name %s - ignoring", name)
                 continue
             resources[name] = "true"

--- a/test.py
+++ b/test.py
@@ -65,17 +65,19 @@ class TestService(unittest.TestCase):
                 )
                 main()
 
-        output = "\n".join(logs.output)
-        self.assertRegex(output, "applying zone: core")
-        self.assertRegex(output, "applying resources:.*airquality")
-        self.assertRegex(output, "applying resources:.*arm64")
-        self.assertRegex(output, "applying resources:.*bme280")
-        self.assertRegex(output, "applying resources:.*cuda102")
-        self.assertRegex(output, "applying resources:.*gps")
-        self.assertRegex(output, "applying resources:.*gpu")
-        self.assertRegex(output, "applying resources:.*metone-es-642")
-        self.assertRegex(output, "applying resources:.*vaisala-wxt-535")
-        self.assertRegex(output, "invalid device name Invalid_device - ignoring")
+                # combine all log output into single string to make easier to test
+                output = "\n".join(logs.output)
+
+            self.assertRegex(output, "applying zone: core")
+            self.assertRegex(output, "applying resources:.*airquality")
+            self.assertRegex(output, "applying resources:.*arm64")
+            self.assertRegex(output, "applying resources:.*bme280")
+            self.assertRegex(output, "applying resources:.*cuda102")
+            self.assertRegex(output, "applying resources:.*gps")
+            self.assertRegex(output, "applying resources:.*gpu")
+            self.assertRegex(output, "applying resources:.*metone-es-642")
+            self.assertRegex(output, "applying resources:.*vaisala-wxt-535")
+            self.assertRegex(output, "invalid device name Invalid_device - ignoring")
 
     def testNXAgent(self, mock_k_lic, mock_k_lkc, mock_k_core, mock_subprocess):
         with patch("argparse.ArgumentParser.parse_args") as mock:

--- a/test.py
+++ b/test.py
@@ -64,12 +64,15 @@ class TestService(unittest.TestCase):
                     oneshot=True,
                 )
                 main()
+
         output = "\n".join(logs.output)
-        self.assertIn(
-            "INFO:root:applying resources: airquality, arm64, bme280, cuda102, gps, gpu",
-            output,
-        )
-        self.assertIn("INFO:root:applying zone: core", output)
+        self.assertRegex(output, "applying zone: core")
+        self.assertRegex(output, "applying resources:.*airquality")
+        self.assertRegex(output, "applying resources:.*arm64")
+        self.assertRegex(output, "applying resources:.*bme280")
+        self.assertRegex(output, "applying resources:.*cuda102")
+        self.assertRegex(output, "applying resources:.*gps")
+        self.assertRegex(output, "applying resources:.*gpu")
         self.assertRegex(output, "applying resources:.*metone-es-642")
         self.assertRegex(output, "applying resources:.*vaisala-wxt-535")
         self.assertRegex(output, "invalid device name Invalid_device - ignoring")

--- a/test.py
+++ b/test.py
@@ -69,10 +69,10 @@ class TestService(unittest.TestCase):
             "INFO:root:applying resources: airquality, arm64, bme280, cuda102, gps, gpu",
             output,
         )
-        self.assertIn("metone-es-642", output)
-        self.assertIn("vaisala-wxt-535", output)
-        self.assertIn("invalid device name Invalid_device - ignoring", output)
         self.assertIn("INFO:root:applying zone: core", output)
+        self.assertRegex(output, "applying resources:.*metone-es-642")
+        self.assertRegex(output, "applying resources:.*vaisala-wxt-535")
+        self.assertRegex(output, "invalid device name Invalid_device - ignoring")
 
     def testNXAgent(self, mock_k_lic, mock_k_lkc, mock_k_core, mock_subprocess):
         with patch("argparse.ArgumentParser.parse_args") as mock:

--- a/test.py
+++ b/test.py
@@ -47,6 +47,9 @@ class TestService(unittest.TestCase):
             # make the fake device and system files
             Path(self.root, "dev/gps").touch()
             Path(self.root, "dev/airquality").touch()
+            Path(self.root, "dev/waggle-metone-es-642").touch()
+            Path(self.root, "dev/waggle-vaisala-wxt-535").touch()
+            Path(self.root, "dev/waggle-Invalid_device").touch()
             with open(Path(self.root, "sys/bus/iio/devices/iio1/name"), "w") as f:
                 f.write("bme280")
 
@@ -61,11 +64,15 @@ class TestService(unittest.TestCase):
                     oneshot=True,
                 )
                 main()
+        output = "\n".join(logs.output)
         self.assertIn(
             "INFO:root:applying resources: airquality, arm64, bme280, cuda102, gps, gpu",
-            logs.output,
+            output,
         )
-        self.assertIn("INFO:root:applying zone: core", logs.output)
+        self.assertIn("metone-es-642", output)
+        self.assertIn("vaisala-wxt-535", output)
+        self.assertIn("invalid device name Invalid_device - ignoring", output)
+        self.assertIn("INFO:root:applying zone: core", output)
 
     def testNXAgent(self, mock_k_lic, mock_k_lkc, mock_k_core, mock_subprocess):
         with patch("argparse.ArgumentParser.parse_args") as mock:


### PR DESCRIPTION
This PR adds support to the device labeler for waggle-* udev based device names.

For example, if we have a udev rule which adds a `/dev/waggle-metone-es-642` device name, the labeler will add a `resource.metone-es-642` label to that compute.
